### PR TITLE
Remove container dependency from nginx

### DIFF
--- a/docker-compose-proxy.yaml
+++ b/docker-compose-proxy.yaml
@@ -14,10 +14,6 @@ services:
       - "80:80"
       - "9000"
       - "9001"
-    depends_on:
-      - minio
-      - tusd
-      - gatekeeper
     healthcheck:
       test: ["CMD-SHELL", "curl --silent --fail localhost:80/health-check || exit 1"]
       interval: 10s


### PR DESCRIPTION
## 🤔 Problem
No dependency is needed for nginx.

## 🧐 Solution
Remove dependency.

## 🤨 Rationale
If we need to access pgadmin, for example, we will need all containers to be healthy.