### PR TITLE
Fix `gatekeeper_db` as hostname for container

### DIFF
--- a/config.py
+++ b/config.py
@@ -3,4 +3,4 @@ SQLALCHEMY_DATABASE_URI = 'postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@localhost:
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 MIGRATION_DIR = 'migrations'
 SQLALCHEMY_ECHO = True
-CASBIN_DATABASE_URL = "postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_gatekeeper-db_1:5432/gatekeeper_db"
+CASBIN_DATABASE_URL = "postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_db:5432/gatekeeper_db"

--- a/config_prod.py
+++ b/config_prod.py
@@ -1,7 +1,7 @@
 DEBUG = True
-SQLALCHEMY_DATABASE_URI = 'postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_gatekeeper-db_1:5432/gatekeeper_db'
+SQLALCHEMY_DATABASE_URI = 'postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_db:5432/gatekeeper_db'
 SQLALCHEMY_TRACK_MODIFICATIONS = False
 MIGRATION_DIR = 'migrations'
 SQLALCHEMY_ECHO = True
-CASBIN_DATABASE_URL = "postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_gatekeeper-db_1:5432/gatekeeper_db"
-CASBIN_WATCHER_HOST = "gatekeeper_gatekeeper-db_1"
+CASBIN_DATABASE_URL = "postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_db:5432/gatekeeper_db"
+CASBIN_WATCHER_HOST = "gatekeeper_db"

--- a/dev.env
+++ b/dev.env
@@ -9,5 +9,5 @@ DB_USER=gk_admin
 DB_PASSWORD=WYnAG9!qzhfx7hDatJcs
 DB_PORT=5432
 DB_NAME=gatekeeper_db
-CASBIN_WATCHER_HOST=gatekeeper_gatekeeper-db_1
+CASBIN_WATCHER_HOST=gatekeeper_db
 CASBIN_DATABASE_URL=postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@127.0.0.1:5432/gatekeeper_db

--- a/docker-compose-database.yaml
+++ b/docker-compose-database.yaml
@@ -4,6 +4,7 @@ services:
   gatekeeper-db:
     image: postgres
     restart: always
+    hostname: gatekeeper_db
     # TODO: create .env file and create new passwords
     # See more: https://docs.docker.com/compose/environment-variables/set-environment-variables/
     # Trello Card: https://trello.com/c/SRvATXrW

--- a/docker-compose-infrastructure.yaml
+++ b/docker-compose-infrastructure.yaml
@@ -9,9 +9,9 @@ services:
     environment:
       # Move to .env file
       - APP_CONFIG_FILE=/app/config_prod.py
-      - CASBIN_DATABASE_URL=postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_gatekeeper-db_1:5432/gatekeeper_db
-      - CASBIN_WATCHER_HOST=gatekeeper_gatekeeper-db_1
-      - DB_HOST=gatekeeper_gatekeeper-db_1
+      - CASBIN_DATABASE_URL=postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_db:5432/gatekeeper_db
+      - CASBIN_WATCHER_HOST=gatekeeper_db
+      - DB_HOST=gatekeeper_db
       - DB_USER=gk_admin
       - DB_PASSWORD=WYnAG9!qzhfx7hDatJcs
       - DB_PORT=5432

--- a/prod.env
+++ b/prod.env
@@ -1,7 +1,7 @@
 DEBUG=True
-SQLALCHEMY_DATABASE_URI='postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_gatekeeper-db_1:5432/gatekeeper_db'
+SQLALCHEMY_DATABASE_URI='postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_db:5432/gatekeeper_db'
 SQLALCHEMY_TRACK_MODIFICATIONS=False
 MIGRATION_DIR='migrations'
 SQLALCHEMY_ECHO=True
-CASBIN_DATABASE_URL="postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_gatekeeper-db_1:5432/gatekeeper_db"
-CASBIN_WATCHER_HOST="gatekeeper_gatekeeper-db_1"
+CASBIN_DATABASE_URL="postgresql://gk_admin:WYnAG9!qzhfx7hDatJcs@gatekeeper_db:5432/gatekeeper_db"
+CASBIN_WATCHER_HOST="gatekeeper_db"


### PR DESCRIPTION
## 🤔 Problem
The hostname changes based on the docker version and operational system.

## 🧐 Solution
I fixed the container hostname as `gatekeeper_db` for postgresql database.

## 🤨 Rationale
<!-- Why was it implemented the way it was? -->
Independent from the environment, the hostname for postgresql database containers should be the same to avoid configuration mismatches. So, I set the hostname on docker compose file `docker-compose-database.yaml` and replace all configs to use this name.

