### PR TITLE
Enable `X-User-Id` custom header for tus.io

### DIFF
--- a/docker-compose-infrastructure.yaml
+++ b/docker-compose-infrastructure.yaml
@@ -40,7 +40,7 @@ services:
       - "1080:1080"
     env_file:
       - ${ENV_FILE_PATH}
-    command: -port 1080 -s3-bucket datamap -s3-endpoint http://minio:9000
+    command: -port 1080 -s3-bucket datamap -s3-endpoint http://minio:9000 -cors-allow-headers X-User-Id
     depends_on: 
       - minio
     networks:


### PR DESCRIPTION
## 🤔 Problem
Error when sending a custom header `X-User-Id` to tus.io locally.

## 🧐 Solution
Configured `-cors-allow-headers X-User-Id` when the tus.io initialize.

## 🤨 Rationale
To avoid CORS errors running locally, a new custom header was allowed.
This should note be a problem in production environment.