### PR TITLE
Change not found to not authorized

### DIFF
--- a/app/service/dataset.py
+++ b/app/service/dataset.py
@@ -95,7 +95,11 @@ class DatasetService:
     def _determine_tenancies(
         self, user_id: UUID, tenancies: list[str] = []
     ) -> list[str]:
-        user = self._user_service.fetch_by_id(id=user_id)
+    
+        try:
+            user = self._user_service.fetch_by_id(id=user_id)
+        except NotFoundException:
+            raise UnauthorizedException(f"unauthorized_tenancy '{tenancies}' for user '{user_id}'")
 
         if not tenancies:
             tenancies = user.tenancies

--- a/app/service/dataset_test.py
+++ b/app/service/dataset_test.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock, patch
 from uuid import uuid4
 from app.exception.illegal_state import IllegalStateException
 from app.exception.not_found import NotFoundException
+from app.exception.unauthorized import UnauthorizedException
 from app.repository.dataset import DatasetRepository
 from app.repository.dataset_version import DatasetVersionRepository
 from app.service.user import UserService
@@ -64,6 +65,22 @@ class TestDatasetService(unittest.TestCase):
         )
         self.assertIsNotNone(result)
         self.dataset_repository.fetch.assert_called_once()
+        
+    def test_fetch_dataset_by_user_not_found(self):
+        dataset_id = uuid4()
+        user_id = uuid4()
+        tenancies = ["tenancy1"]
+        dataset_db = Mock(spec=DatasetDBModel)
+        mocked_version = Mock(spec=DatasetVersionDBModel)
+        mocked_version.files = [Mock(spec=DataFileDBModel)]
+        dataset_db.versions = [mocked_version]
+        self.user_service.fetch_by_id.side_effect = NotFoundException("user not found")
+        
+        # when + then
+        with self.assertRaises(UnauthorizedException):
+            self.dataset_service.fetch_dataset(
+                dataset_id=dataset_id, user_id=user_id, tenancies=tenancies
+            )
 
     def test_update_dataset_not_found(self):
         dataset_id = uuid4()

--- a/migrations/versions/2024_05_22_2228-25a8f93fb344_add_unique_constraint_in_ds_version.py
+++ b/migrations/versions/2024_05_22_2228-25a8f93fb344_add_unique_constraint_in_ds_version.py
@@ -8,7 +8,6 @@ Create Date: 2024-05-22 22:28:10.623569
 from typing import Sequence, Union
 
 from alembic import op
-import sqlalchemy as sa
 
 
 # revision identifiers, used by Alembic.


### PR DESCRIPTION
## 🤔 Problem
Get dataset list for a user not authorized or with invalid tenancy was returning 404 instead of 401.
Also a small fix after run the `ruff check --fix`.

## 🧐 Solution
Catch the `NotFoundException` exception and switch to `UnauthorizedException`.

## 🤨 Rationale
If the `user_id+tenancy` is not found in a `GET /datasets` we should return unauthorized instead of not found, because the issue is that the user doesn't have permission to list datasets.