### PR TITLE
Prune docker images on deployment

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ docker-stop:
 docker-down:
 	@echo "${On_Green}Downing docker containers${Color_Off}"
 	time docker-compose -f docker-compose-infrastructure.yaml -f docker-compose-database.yaml down
+	time docker image prune -a
 
 docker-deployment: docker-build docker-stop docker-down docker-run
 	


### PR DESCRIPTION
## 🤔 Problem
Old images on the datamap server must be pruned

## 🧐 Solution
Add prune images on makefile deployment script

## 🤨 Rationale
Let's keep only the last images version on the server