### PR TITLE
Fix users and clients api auth

### DIFF
--- a/app/controller/v1/client/client.py
+++ b/app/controller/v1/client/client.py
@@ -3,6 +3,7 @@ from fastapi import APIRouter, Depends, Response
 from dependency_injector.wiring import inject, Provide
 from app.container import Container
 from app.controller.interceptor.authentication import authenticate
+from app.controller.interceptor.authorization import authorize
 from app.controller.v1.client.resource import (
     ClientCreateRequest,
     ClientCreateResponse,
@@ -20,7 +21,7 @@ router = APIRouter(
 
 
 # GET /clients
-@router.get("/")
+@router.get("/", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def get_all(
     service: ClientService = Depends(Provide[Container.client_service]),
@@ -35,7 +36,7 @@ async def get_all(
 
 
 # GET /clients/{key}
-@router.get("/{key}", dependencies=[Depends(authenticate)])
+@router.get("/{key}", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def get_by_key(
     key: UUID,
@@ -53,7 +54,7 @@ async def get_by_key(
 
 
 # PUT /clients/{key}
-@router.put("/{key}")
+@router.put("/{key}", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def update_by_key(
     key: UUID,
@@ -65,7 +66,7 @@ async def update_by_key(
 
 
 # POST /clients
-@router.post("/", status_code=201)
+@router.post("/", status_code=201, dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def create(
     payload: ClientCreateRequest,
@@ -76,7 +77,7 @@ async def create(
 
 
 # DELETE /clients/{key}
-@router.delete("/{key}", status_code=204)
+@router.delete("/{key}", status_code=204, dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def delete(
     key: UUID,
@@ -87,7 +88,7 @@ async def delete(
 
 
 # POST /clients/{key}/enable
-@router.post("/{key}/enable")
+@router.post("/{key}/enable", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def enable(
     key: UUID,

--- a/app/controller/v1/user/user.py
+++ b/app/controller/v1/user/user.py
@@ -3,6 +3,8 @@ from uuid import UUID
 from fastapi import APIRouter, Depends
 
 from app.container import Container
+from app.controller.interceptor.authentication import authenticate
+from app.controller.interceptor.authorization import authorize
 from app.controller.v1.user.resource import (
     UserCreateResponse,
     UserEnforceRequest,
@@ -46,7 +48,7 @@ def _adapt_post_response(user_id: UUID) -> UserCreateResponse:
 
 
 # GET /users
-@router.get("/")
+@router.get("/", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def search(
     email: str = None,
@@ -59,7 +61,7 @@ async def search(
 
 
 # GET /users/{id}
-@router.get("/{id}")
+@router.get("/{id}", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def get(
     id: UUID,
@@ -71,7 +73,7 @@ async def get(
 
 
 # POST /users
-@router.post("/")
+@router.post("/", dependencies=[Depends(authenticate)])
 @inject
 async def create(
     payload: UserCreateRequest,
@@ -90,7 +92,7 @@ async def create(
 
 
 # PUT /users/{id}
-@router.put("/{id}")
+@router.put("/{id}", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def update(
     id: UUID,
@@ -102,7 +104,7 @@ async def update(
 
 
 # DELETE /users/{id}
-@router.delete("/{id}")
+@router.delete("/{id}", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def delete(
     id: UUID,
@@ -113,7 +115,7 @@ async def delete(
 
 
 # PUT /users/{id}/enable
-@router.put("/{id}/enable")
+@router.put("/{id}/enable", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def enable(
     id: UUID,
@@ -124,7 +126,7 @@ async def enable(
 
 
 # PUT /users/{id}/roles
-@router.put("/{id}/roles")
+@router.put("/{id}/roles", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def add_roles(
     id: UUID,
@@ -136,7 +138,7 @@ async def add_roles(
 
 
 # DELETE /users/{id}/roles
-@router.delete("/{id}/roles")
+@router.delete("/{id}/roles", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def remove_roles(
     id: UUID,
@@ -148,7 +150,7 @@ async def remove_roles(
 
 
 # PUT /users/{id}/providers
-@router.put("/{id}/providers")
+@router.put("/{id}/providers", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def add_provider(
     id: UUID,
@@ -160,7 +162,7 @@ async def add_provider(
 
 
 # DELETE /users/{id}/providers
-@router.delete("/{id}/providers")
+@router.delete("/{id}/providers", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def remove_provider(
     id: UUID,
@@ -173,7 +175,7 @@ async def remove_provider(
 
 
 # GET /users/providers/{provider}/{reference}
-@router.get("/providers/{provider}/{reference}")
+@router.get("/providers/{provider}/{reference}", dependencies=[Depends(authenticate)])
 @inject
 async def get_by_provider_reference(
     provider: str,
@@ -188,7 +190,7 @@ async def get_by_provider_reference(
 
 
 # POST /users/{id}/tenancies
-@router.post("/{id}/tenancies")
+@router.post("/{id}/tenancies", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def add_tenancy(
     id: UUID,
@@ -200,7 +202,7 @@ async def add_tenancy(
 
 
 # DELETE /users/{id}/tenancies
-@router.delete("/{id}/tenancies")
+@router.delete("/{id}/tenancies", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def remove_tenancy(
     id: UUID,
@@ -212,7 +214,7 @@ async def remove_tenancy(
 
 
 # POST /users/{id}/enforce
-@router.post("/{id}/enforce")
+@router.post("/{id}/enforce", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def enforce(
     id: UUID,
@@ -226,7 +228,7 @@ async def enforce(
 
 
 # POST /force-policy-reload
-@router.post("/force-policy-reload")
+@router.post("/force-policy-reload", dependencies=[Depends(authenticate), Depends(authorize)])
 @inject
 async def force_policy_reload(
     service: UserService = Depends(Provide[Container.user_service]),


### PR DESCRIPTION
## 🤔 Problem
Users and Clients API weren't properly secure.

## 🧐 Solution
Add `authenticate` and `authorize` interceptors to selected APIs.

## 🤨 Rationale
APIs were exposed to internet freely.